### PR TITLE
change open_close to windowcoverings_closed capability

### DIFF
--- a/app.json
+++ b/app.json
@@ -5255,7 +5255,7 @@
       ],
       "class": "curtain",
       "capabilities": [
-        "open_close",
+        "windowcoverings_closed",
         "windowcoverings_state",
         "light_level",
         "measure_battery",

--- a/drivers/curtains_ble/device.js
+++ b/drivers/curtains_ble/device.js
@@ -12,10 +12,6 @@ class CurtainsBLEDevice extends Homey.Device
 	 */
 	async onInit()
 	{
-		if (this.hasCapability('open_close'))
-		{
-			this.removeCapability('open_close');
-		}
 		if (!this.hasCapability('position'))
 		{
 			this.addCapability('position');
@@ -31,10 +27,6 @@ class CurtainsBLEDevice extends Homey.Device
 		if (!this.hasCapability('windowcoverings_state'))
 		{
 			this.addCapability('windowcoverings_state');
-		}
-		if (!this.hasCapability('windowcoverings_closed'))
-		{
-			this.addCapability('windowcoverings_closed');
 		}
 
 		this.bestRSSI = 100;
@@ -57,7 +49,15 @@ class CurtainsBLEDevice extends Homey.Device
 		}
 
 		// register a capability listener
-		this.registerCapabilityListener('windowcoverings_closed', this.onCapabilityopenClose.bind(this));
+		if (this.hasCapability('open_close'))
+		{
+			this.registerCapabilityListener('open_close', this.onCapabilityopenClose.bind(this));
+		}
+
+		if (this.hasCapability('windowcoverings_closed'))
+		{
+			this.registerCapabilityListener('windowcoverings_closed', this.onCapabilityopenClose.bind(this));
+		}
 		this.registerCapabilityListener('windowcoverings_set', this.onCapabilityPosition.bind(this));
 		this.registerCapabilityListener('windowcoverings_state', this.onCapabilityState.bind(this));
 
@@ -405,7 +405,18 @@ class CurtainsBLEDevice extends Homey.Device
 						position = 1 - position;
 					}
 
-					if (position > 0.5)
+					if (this.hasCapability('open_close'))
+					{
+						if (position > 0.5)
+						{
+							this.setCapabilityValue('open_close', true).catch(this.error);
+						}
+						else
+						{
+							this.setCapabilityValue('open_close', false).catch(this.error);
+						}
+					}
+					else if (position > 0.5)
 					{
 						this.setCapabilityValue('windowcoverings_closed', true).catch(this.error);
 					}
@@ -489,7 +500,18 @@ class CurtainsBLEDevice extends Homey.Device
 					this.setCapabilityValue('windowcoverings_set', position).catch(this.error);
 					this.setCapabilityValue('position', position * 100).catch(this.error);
 
-					if (position > 0.5)
+					if (this.hasCapability('open_close'))
+					{
+						if (position > 0.5)
+						{
+							this.setCapabilityValue('open_close', true).catch(this.error);
+						}
+						else
+						{
+							this.setCapabilityValue('open_close', false).catch(this.error);
+						}
+					}
+					else if (position > 0.5)
 					{
 						this.setCapabilityValue('windowcoverings_closed', true).catch(this.error);
 					}

--- a/drivers/curtains_ble/device.js
+++ b/drivers/curtains_ble/device.js
@@ -12,9 +12,9 @@ class CurtainsBLEDevice extends Homey.Device
 	 */
 	async onInit()
 	{
-		if (!this.hasCapability('open_close'))
+		if (this.hasCapability('open_close'))
 		{
-			this.addCapability('open_close');
+			this.removeCapability('open_close');
 		}
 		if (!this.hasCapability('position'))
 		{
@@ -31,6 +31,10 @@ class CurtainsBLEDevice extends Homey.Device
 		if (!this.hasCapability('windowcoverings_state'))
 		{
 			this.addCapability('windowcoverings_state');
+		}
+		if (!this.hasCapability('windowcoverings_closed'))
+		{
+			this.addCapability('windowcoverings_closed');
 		}
 
 		this.bestRSSI = 100;
@@ -53,7 +57,7 @@ class CurtainsBLEDevice extends Homey.Device
 		}
 
 		// register a capability listener
-		this.registerCapabilityListener('open_close', this.onCapabilityopenClose.bind(this));
+		this.registerCapabilityListener('windowcoverings_closed', this.onCapabilityopenClose.bind(this));
 		this.registerCapabilityListener('windowcoverings_set', this.onCapabilityPosition.bind(this));
 		this.registerCapabilityListener('windowcoverings_state', this.onCapabilityState.bind(this));
 
@@ -293,6 +297,7 @@ class CurtainsBLEDevice extends Homey.Device
 
 			this.homey.app.updateLog(`Connecting to BLE device: ${name}`);
 			const blePeripheral = await bleAdvertisement.connect();
+
 			this.homey.app.updateLog(`BLE device ${name} connected`);
 
 			const reqBuf = Buffer.from(bytes);
@@ -402,11 +407,11 @@ class CurtainsBLEDevice extends Homey.Device
 
 					if (position > 0.5)
 					{
-						this.setCapabilityValue('open_close', true).catch(this.error);
+						this.setCapabilityValue('windowcoverings_closed', true).catch(this.error);
 					}
 					else
 					{
-						this.setCapabilityValue('open_close', false).catch(this.error);
+						this.setCapabilityValue('windowcoverings_closed', false).catch(this.error);
 					}
 
 					if (position === 0)
@@ -486,11 +491,11 @@ class CurtainsBLEDevice extends Homey.Device
 
 					if (position > 0.5)
 					{
-						this.setCapabilityValue('open_close', true).catch(this.error);
+						this.setCapabilityValue('windowcoverings_closed', true).catch(this.error);
 					}
 					else
 					{
-						this.setCapabilityValue('open_close', false).catch(this.error);
+						this.setCapabilityValue('windowcoverings_closed', false).catch(this.error);
 					}
 
 					if (position === 0)

--- a/drivers/curtains_ble/driver.compose.json
+++ b/drivers/curtains_ble/driver.compose.json
@@ -23,7 +23,7 @@
   ],
   "class": "curtain",
   "capabilities": [
-    "open_close",
+    "windowcoverings_closed",
     "windowcoverings_state",
     "light_level",
     "measure_battery",


### PR DESCRIPTION
I changed the open_close to the windowcoverings_closed capabilty as this is a native one and solves the issue below for me.

HomeyLink only syncs native capabilities so open_close is not synced and flows are not available .
I have the Switchbot app on a second Homey Pro and synced with HomeyLink, and with this change I am able to open/close the curtains. 