### PR TITLE
Enable support for S20

### DIFF
--- a/drivers/S10_water_station/driver.compose.json
+++ b/drivers/S10_water_station/driver.compose.json
@@ -1,18 +1,18 @@
 {
   "id": "S10_water_station",
   "name": {
-    "en": "S10 Water Station",
-	"no": "S10 Vannstasjon",
-	"nl": "S10 Waterstation",
-	"da": "S10 Vandstation",
-	"de": "S10 Wasserspeicher",
-	"es": "Estación de Agua S10",
-	"fr": "Station d'Eau S10",
-	"it": "Stazione dell'Acqua S10",
-	"sv": "S10 Vattenstation",
-	"pl": "Stacja Wodna S10",
-	"ru": "Водная станция S10",
-	"ko": "S10 물 스테이션"
+    "en": "S10/S20 Water Station",
+	"no": "S10/S20 Vannstasjon",
+	"nl": "S10/S20 Waterstation",
+	"da": "S10/S20 Vandstation",
+	"de": "S10/S20 Wasserspeicher",
+	"es": "Estación de Agua S10/S20",
+	"fr": "Station d'Eau S10/S20",
+	"it": "Stazione dell'Acqua S10/S20",
+	"sv": "S10/S20 Vattenstation",
+	"pl": "Stacja Wodna S10/S20",
+	"ru": "Водная станция S10/S20",
+	"ko": "S10/S20 물 스테이션"
   },
   "class": "vacuumcleaner",
   "capabilities": [

--- a/drivers/S10_water_station/driver.js
+++ b/drivers/S10_water_station/driver.js
@@ -19,7 +19,7 @@ class S10WaterStationDriver extends HubDriver
 
 	async onPairListDevices({ oAuth2Client })
 	{
-		return this.getHUBDevices(oAuth2Client, ['Robot Vacuum Cleaner S10', 'K10+ Pro']);
+		return this.getHUBDevices(oAuth2Client, ['Robot Vacuum Cleaner S10', 'K10+ Pro', 'Robot Vacuum Cleaner S20']);
 	}
 
 }

--- a/drivers/robot_vacuum_S10_hub/driver.compose.json
+++ b/drivers/robot_vacuum_S10_hub/driver.compose.json
@@ -1,18 +1,18 @@
 {
   "id": "robot_vacuum_S10_hub",
   "name": {
-    "en": "S10 Floor Cleaner",
-	"no": "S10 Gulvvasker",
-	"nl": "S10 Vloerreiniger",
-	"da": "S10 Gulvrenser",
-	"de": "S10 Bodenreiniger",
-	"es": "S10 Limpiador de Suelos",
-	"fr": "S10 Nettoyeur de Sol",
-	"it": "S10 Pulitore per Pavimenti",
-	"sv": "S10 Golvrenare",
-	"pl": "S10 Odkurzacz",
-	"ru": "S10 Робот-пылесос",
-	"ko": "S10 로봇 바닥 청소기"
+    "en": "S10/S20 Floor Cleaner",
+	"no": "S10/S20 Gulvvasker",
+	"nl": "S10/S20 Vloerreiniger",
+	"da": "S10/S20 Gulvrenser",
+	"de": "S10/S20 Bodenreiniger",
+	"es": "S10/S20 Limpiador de Suelos",
+	"fr": "S10/S20 Nettoyeur de Sol",
+	"it": "S10/S20 Pulitore per Pavimenti",
+	"sv": "S10/S20 Golvrenare",
+	"pl": "S10/S20 Odkurzacz",
+	"ru": "S10/S20 Робот-пылесос",
+	"ko": "S10/S20 로봇 바닥 청소기"
   },
   "class": "vacuumcleaner",
   "capabilities": [

--- a/drivers/robot_vacuum_S10_hub/driver.js
+++ b/drivers/robot_vacuum_S10_hub/driver.js
@@ -42,7 +42,7 @@ class HubVacuumS10Driver extends HubDriver
 
 	async onPairListDevices({ oAuth2Client })
 	{
-		return this.getHUBDevices(oAuth2Client, ['Robot Vacuum Cleaner S10']);
+		return this.getHUBDevices(oAuth2Client, ['Robot Vacuum Cleaner S10', 'Robot Vacuum Cleaner S20']);
 	}
 
 	async triggerStateChanged(device, tokens, state)


### PR DESCRIPTION
Add support for S20 Vacuum cleaner. Decided to add it to the S10 as it does not contain extra features as far as i am aware.

I also included the S20 in the water station. I assume it works the same but can not check as i do not have that device.

Device JSON:
```
    {
      "deviceId": "B0E9FEDxxxx",
      "deviceName": "xxxx,
      "deviceType": "Robot Vacuum Cleaner S20",
      "enableCloudService": true,
      "hubDeviceId": ""
    },
```
Status JSON:
```
{
  "workingStatus": "Clearing",
  "onlineStatus": "online",
  "battery": 100,
  "waterBaseBattery": 100,
  "taskType": "standBy",
  "deviceId": "B0E9FEDxxxxx",
  "deviceType": "Robot Vacuum Cleaner S20",
  "hubDeviceId": "000000000000"
}
```