### PR TITLE
fix: correct mA/watt-minute unit conversions in plug_hub and relay_hub

### DIFF
--- a/drivers/plug_hub/device.js
+++ b/drivers/plug_hub/device.js
@@ -90,10 +90,24 @@ class PlugHubDevice extends HubDevice
 				{
 					this.setCapabilityValue('onoff', data.power === 'on').catch(this.error);
 				}
-				if (data.electricCurrent)
+				if (data.electricCurrent !== undefined)
 				{
-					this.setCapabilityValue('measure_current', data.electricCurrent).catch(this.error);
+					// SwitchBot reports electricCurrent in milliAmps (per the Plug Mini (US)
+					// API docs) but Homey's measure_current capability expects Amps.
+					this.setCapabilityValue('measure_current', data.electricCurrent / 1000).catch(this.error);
 					this.setCapabilityValue('measure_voltage', data.voltage).catch(this.error);
+				}
+
+				// 'weight' is the instantaneous power draw in Watts. Only the metering plugs
+				// (Plug Mini US/JP) report it, so the capability is added on demand and the
+				// plain Plug is left alone. Homey Energy derives cumulative kWh from this.
+				if (typeof data.weight === 'number')
+				{
+					if (!this.hasCapability('measure_power'))
+					{
+						await this.addCapability('measure_power').catch(this.error);
+					}
+					this.setCapabilityValue('measure_power', data.weight).catch(this.error);
 				}
 			}
 			this.unsetWarning().catch(this.error);

--- a/drivers/relay_hub/device.js
+++ b/drivers/relay_hub/device.js
@@ -129,8 +129,11 @@ class RelayHubDevice extends HubDevice
 				{
 					this.setCapabilityValue('measure_voltage', data.voltage).catch(this.error);
 					this.setCapabilityValue('measure_power', data.power).catch(this.error);
-					this.setCapabilityValue('measure_current', data.electricCurrent).catch(this.error);
-					this.setCapabilityValue('meter_power', data.usedElectricity).catch(this.error);
+					// Relay Switch 1PM reports electricCurrent in mA; measure_current expects Amps.
+					this.setCapabilityValue('measure_current', data.electricCurrent / 1000).catch(this.error);
+					// usedElectricity is daily consumption in watt-minutes; meter_power expects kWh
+					// (watt-minutes / 60 = Wh, / 1000 = kWh). Matches plug_eu_hub.
+					this.setCapabilityValue('meter_power', data.usedElectricity / 60000).catch(this.error);
 				}
 			}
 			this.unsetWarning().catch(this.error);


### PR DESCRIPTION
## Summary

Three unit-conversion bugs in the electrical readings of two hub drivers. All three are visible on a live Homey Pro mini running v2.0.87 with 27 Plug Mini (US) and 3 Relay Switch 1PM devices. `plug_eu_hub` and `relay2pm_hub` already do the right thing — these two drivers were just missed.

## 1. `plug_hub` — `electricCurrent` is mA, not Amps

```js
this.setCapabilityValue('measure_current', data.electricCurrent)
```

[`plug-mini-us.md`](https://github.com/OpenWonderLabs/SwitchBotAPI/blob/main/devices/plugs-switches/plug-mini-us.md) documents `electricCurrent` as **mA**; Homey's `measure_current` expects **Amps**.

A 1320 mA draw was displayed as **1320 A**.

## 2. `plug_hub` — `weight` (Watts) was never read

`driver.compose.json` declared only `["onoff","measure_current","measure_voltage"]`, and `getHubDeviceValues()` never touched `weight`. These plugs therefore contributed **nothing** to Homey Energy, despite the API returning instantaneous Watts in every status response.

`measure_power` is added via `addCapability()` at runtime rather than declared in compose, for two reasons:

- this driver also serves the plain `Plug` (`['Plug', 'Plug Mini (JP)', 'Plug Mini (US)']`), which has no metering — a compose entry would give it a permanently null Watt tile;
- runtime `addCapability` also migrates already-paired devices, which a compose change alone would not.

`meter_power` is deliberately **not** set here — the US plug status has no cumulative energy field (`electricityOfDay` is *minutes of use*, not energy), and Homey Energy derives kWh from `measure_power` on its own.

## 3. `relay_hub` — `electricCurrent` (mA) and `usedElectricity` (watt-minutes)

```js
this.setCapabilityValue('measure_current', data.electricCurrent)
this.setCapabilityValue('meter_power',     data.usedElectricity)
```

[`relay-switch-1pm.md`](https://github.com/OpenWonderLabs/SwitchBotAPI/blob/main/devices/plugs-switches/relay-switch-1pm.md) documents `electricCurrent` as **mA** and `usedElectricity` as **watt-minutes**. `meter_power` expects **kWh**.

The `meter_power` one is the more serious of the two: because it is a cumulative energy capability, Homey Energy was being told a ceiling light had consumed **4500 kWh**.

## Before / after on live hardware

| Device | Capability | Before | After |
|---|---|---|---|
| Plug Mini (US) | `measure_current` | 1320 A | **1.32 A** |
| Plug Mini (US) | `measure_power` | *(absent)* | **144.4 W** |
| Relay Switch 1PM | `measure_current` | 85 A | **0.085 A** |
| Relay Switch 1PM | `meter_power` | 4500 kWh | **0.075 kWh** |

Sanity check across all 71 SwitchBot devices on that Homey (101 numeric electrical readings): after the change, no current above 50 A, no meter above 100 kWh, and `measure_power` never exceeds `measure_voltage × measure_current` on any device. The 144.4 W plug reads 1.32 A × 119 V = 157 VA, i.e. power factor 0.92 — consistent rather than merely plausible.

`homey app validate --level publish` passes.

## Known caveat, unchanged by this PR

`usedElectricity` is a **daily** counter that resets, while Homey's `meter_power` is meant to be monotonic. This PR only corrects the scale and leaves that behaviour as-is, matching what `plug_eu_hub` already does. Happy to revisit in a follow-up if you'd prefer accumulation instead.
